### PR TITLE
Add the presentation role to progress bar

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -1088,7 +1088,8 @@ function block_progress_bar($modules, $config, $events, $userid, $instance, $att
     $dateformat = get_string('strftimerecentfull', 'langconfig');
     $tableoptions = array('class' => 'progressBarProgressTable',
                           'cellpadding' => '0',
-                          'cellspacing' => '0');
+                          'cellspacing' => '0',
+                          'role' => 'presentation');
 
     // Get colours and use defaults if they are not set in global settings.
     $colournames = array(


### PR DESCRIPTION
To help with accesibility we need to add the presentation role to the progress bar table to make sure they dont go through all the blocks in the progress bar
