### PR TITLE
Remove unwanted js include

### DIFF
--- a/overview.php
+++ b/overview.php
@@ -317,10 +317,6 @@ if ($CFG->enablenotes || $CFG->messaging) {
     echo html_writer::end_tag('form');
 }
 
-// Organise access to JS for messaging.
-$module = array('name' => 'core_user', 'fullpath' => '/user/module.js');
-$PAGE->requires->js_init_call('M.core_user.init_participation', null, false, $module);
-
 // Organise access to JS for progress bars.
 $jsmodule = array('name' => 'block_progress', 'fullpath' => '/blocks/progress/module.js');
 $arguments = array(array($progressblock->id), $userids);


### PR DESCRIPTION
Remove include /user/module.js -- No longer supported in moodle3.4